### PR TITLE
Syncer role

### DIFF
--- a/contracts/v2/WAVAXVaultV2.sol
+++ b/contracts/v2/WAVAXVaultV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
@@ -9,7 +9,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import {IWAVAX} from "./interfaces/WAVAX.sol";
+import {IWAVAX} from "../interfaces/WAVAX.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /// @title WAVAXVault
@@ -17,7 +17,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 ///         distribute rewards, and manage deposits from staking with a focus on access control and upgradeability.
 /// @dev The contract uses OpenZeppelin's upgradeable contract patterns, including ERC4626 for tokenized vault,
 ///      UUPS for upgradeability, Ownable2Step for ownership management, and AccessControl for role-based permissions.
-contract WAVAXVault is
+contract WAVAXVaultV2 is
     Initializable,
     Ownable2StepUpgradeable,
     ERC4626Upgradeable,
@@ -28,6 +28,7 @@ contract WAVAXVault is
     using Address for address;
 
     bytes32 public constant APPROVED_NODE_OPERATOR = keccak256("APPROVED_NODE_OPERATOR");
+    bytes32 public constant REWARDS_SYNCER = keccak256("REWARDS_SYNCER");
 
     event AVAXCapUpdated(uint256 newMax);
     event TargetAPRUpdated(uint256 newTargetAPR);
@@ -45,6 +46,15 @@ contract WAVAXVault is
         require(
             owner() == _msgSender() || hasRole(APPROVED_NODE_OPERATOR, _msgSender()),
             "Caller is not the owner or an approved node operator"
+        );
+        _;
+    }
+
+    /// @notice Restricts functions to the contract owner or rewards syncer only.
+    modifier onlyOwnerOrRewardsSyncer() {
+        require(
+            owner() == _msgSender() || hasRole(REWARDS_SYNCER, _msgSender()),
+            "Caller is not the owner or rewards syncer"
         );
         _;
     }
@@ -143,7 +153,7 @@ contract WAVAXVault is
 
     /// @notice Updates the rewards based on the time elapsed since the last update.
     /// @dev Adds the calculated pending rewards to the total staking assets and updates the timestamp.
-    function updateRewards() external onlyOwnerOrApprovedNodeOperator {
+    function updateRewards() external onlyOwnerOrApprovedNodeOperator onlyOwnerOrRewardsSyncer {
         _updateRewards();
     }
     /// @notice Allows depositing tokens back into the vault from staking, adjusting the staking total assets accordingly.

--- a/contracts/v2/WAVAXVaultV2.sol
+++ b/contracts/v2/WAVAXVaultV2.sol
@@ -51,10 +51,11 @@ contract WAVAXVaultV2 is
     }
 
     /// @notice Restricts functions to the contract owner or rewards syncer only.
-    modifier onlyOwnerOrRewardsSyncer() {
+    modifier onlyRewardsUpdater() {
         require(
-            owner() == _msgSender() || hasRole(REWARDS_SYNCER, _msgSender()),
-            "Caller is not the owner or rewards syncer"
+            owner() == _msgSender() || hasRole(APPROVED_NODE_OPERATOR, _msgSender())
+                || hasRole(REWARDS_SYNCER, _msgSender()),
+            "Unauthorized rewards updater account"
         );
         _;
     }
@@ -153,7 +154,7 @@ contract WAVAXVaultV2 is
 
     /// @notice Updates the rewards based on the time elapsed since the last update.
     /// @dev Adds the calculated pending rewards to the total staking assets and updates the timestamp.
-    function updateRewards() external onlyOwnerOrApprovedNodeOperator onlyOwnerOrRewardsSyncer {
+    function updateRewards() external onlyRewardsUpdater {
         _updateRewards();
     }
     /// @notice Allows depositing tokens back into the vault from staking, adjusting the staking total assets accordingly.

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,6 @@ libs = ['lib']
 out = 'out'
 solc = "0.8.20"
 src = 'src'
-
 build_info = true
 extra_output = ["storageLayout"]
 

--- a/script/Anvil.s.sol
+++ b/script/Anvil.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import "./../contracts/WAVAXVault.sol";
+import "./../contracts/v2/WAVAXVaultV2.sol";
+
+import "forge-std/Script.sol";
+
+// Run for anvil network only
+contract AnvilScripts is Script {
+    address owner = 0x73F9d1761eDd28BFEd67c7d5BbfEDf85A3783309;
+    address rewardsSyncer = 0x804C8fC862c342c077fB04614E1C5E8E2C85b6b5;
+    WAVAXVaultV2 vault = WAVAXVaultV2(payable(0x36213ca1483869c5616be738Bf8da7C9B34Ace8d));
+
+    function run() public {
+        vm.startBroadcast(owner);
+        _grantRole();
+        vm.stopBroadcast();
+    }
+
+    function _grantRole() public {
+        vault.grantRole(vault.REWARDS_SYNCER(), rewardsSyncer);
+    }
+
+    function _upgrade() internal {
+        WAVAXVaultV2 v2 = new WAVAXVaultV2();
+        vault.upgradeToAndCall(address(v2), "");
+    }
+}

--- a/test/WAVAXVaultTest.sol
+++ b/test/WAVAXVaultTest.sol
@@ -6,7 +6,7 @@ import "forge-std/console.sol";
 import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 import {WAVAXVault} from "../contracts/WAVAXVault.sol";
-import {WAVAXVaultV2} from "./mocks/WAVAXVaultV2.sol";
+import {WAVAXVaultUpgrade} from "./mocks/WAVAXVaultUpgrade.sol";
 import {MockTokenWAVAX} from "./mocks/MockTokenWAVAX.sol";
 
 contract WAVAXVaultTest is Test {
@@ -163,10 +163,10 @@ contract WAVAXVaultTest is Test {
         address implAddressV1 = Upgrades.getImplementationAddress(address(vault));
 
         assertEq(vault.targetAPR(), 1405);
-        Upgrades.upgradeProxy(address(vault), "WAVAXVaultV2.sol", abi.encodeCall(WAVAXVault.setTargetAPR, 2000));
+        Upgrades.upgradeProxy(address(vault), "WAVAXVaultUpgrade.sol", abi.encodeCall(WAVAXVault.setTargetAPR, 2000));
         address implAddressV2 = Upgrades.getImplementationAddress(address(vault));
 
-        WAVAXVaultV2 v2 = WAVAXVaultV2(payable(address(vault)));
+        WAVAXVaultUpgrade v2 = WAVAXVaultUpgrade(payable(address(vault)));
         assertFalse(implAddressV2 == implAddressV1);
         assertEq(v2.newMethod(), "meow");
     }

--- a/test/mocks/WAVAXVaultUpgrade.sol
+++ b/test/mocks/WAVAXVaultUpgrade.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.20;
 import {WAVAXVault} from "../../contracts/WAVAXVault.sol";
 
 /// @custom:oz-upgrades-from WAVAXVault
-contract WAVAXVaultV2 is WAVAXVault {
+contract WAVAXVaultUpgrade is WAVAXVault {
     function newMethod() public pure returns (string memory) {
         return "meow";
     }

--- a/test/v2/WAVAXVaultV2.t.sol
+++ b/test/v2/WAVAXVaultV2.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import "forge-std/console.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+
+import {WAVAXVaultV2} from "../../contracts/v2/WAVAXVaultV2.sol";
+import {MockTokenWAVAX} from "../mocks/MockTokenWAVAX.sol";
+
+contract WAVAXVaultTest is Test {
+    WAVAXVaultV2 vault;
+    MockTokenWAVAX WAVAX;
+    address owner;
+    address nodeOp1 = address(0x9);
+    address rewardsSyncer = makeAddr("rewardsSyncer");
+
+    event DepositedFromStaking(address indexed caller, uint256 amount);
+
+    event GGPCapUpdated(uint256 newCap);
+
+    error ERC4626ExceededMaxDeposit(address receiver, uint256 assets, uint256 max);
+
+    error OwnableUnauthorizedAccount(address account);
+
+    function setUp() public {
+        owner = address(this);
+        WAVAX = new MockTokenWAVAX(owner);
+
+        address payable proxy = payable(
+            Upgrades.deployUUPSProxy(
+                "WAVAXVaultV2.sol", abi.encodeCall(WAVAXVaultV2.initialize, (address(WAVAX), owner))
+            )
+        );
+        vault = WAVAXVaultV2(payable(proxy));
+
+        vault.grantRole(vault.APPROVED_NODE_OPERATOR(), nodeOp1);
+        WAVAX.approve(address(vault), type(uint256).max);
+
+        WAVAX.transfer(nodeOp1, 100000e18);
+        WAVAX.approve(address(vault), type(uint256).max);
+        vm.prank(nodeOp1);
+        WAVAX.approve(address(vault), type(uint256).max);
+    }
+
+    function testFuzz_OnlyOwnerApprovedNodeOperatorOrNodeSyncerCanUpdadeRewards(address anyone) public {
+        vm.prank(anyone);
+        if (anyone == owner || anyone == nodeOp1 || anyone == rewardsSyncer) {
+            vault.updateRewards();
+        } else {
+            vm.expectRevert();
+            vault.updateRewards();
+        }
+    }
+}

--- a/test/v2/WAVAXVaultV2.t.sol
+++ b/test/v2/WAVAXVaultV2.t.sol
@@ -48,7 +48,7 @@ contract WAVAXVaultTest is Test {
         if (anyone == owner || anyone == nodeOp1 || anyone == rewardsSyncer) {
             vault.updateRewards();
         } else {
-            vm.expectRevert();
+            vm.expectRevert(bytes("Unauthorized rewards updater account"));
             vault.updateRewards();
         }
     }


### PR DESCRIPTION
>[!Warning]
> No overriding risk, bytes32 SYNCER role is attached to bytecode

>[!Note]
> Enable `REWARDS_SYNCER` role
> Constraint `updateRewards` function to be called only by `owner, approved node operator or syncer`
> Test Access Control
> V1 tests passed successfully